### PR TITLE
Fix flash messages when message type is not a symbol

### DIFF
--- a/lib/lb/project/site.rb
+++ b/lib/lb/project/site.rb
@@ -113,7 +113,7 @@ module LB
 
       def messages
         flash.map do |type, message|
-          { message: message }.merge(message_types[type])
+          { message: message }.merge(message_types[type.to_sym])
         end
       end
     end


### PR DESCRIPTION
Rack does not preserve symbols when storing flash in the session store.